### PR TITLE
Update "browserify" to version ^12.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "resource-loader": "^1.6.2"
   },
   "devDependencies": {
-    "browserify": "^11.1.0",
+    "browserify": "^12.0.1",
     "chai": "^3.2.0",
     "del": "^2.0.2",
     "gulp": "^3.9.0",


### PR DESCRIPTION
# Automatic Dependency Update
#12.0.1 / 2015-10-28
- transform tests
#12.0.0 / 2015-10-26
- 12.0.0
- update devdeps
- update glob and shell-quote
- update builtins deps
  These mostly include updates for newer versions of node. stream-http dropped IE8 support - needs shims to work (see [#1384](https://github.com/substack/node-browserify/issues/1384)).
- update deps for streams3
- update module-deps & fix symlink bug (also uses streams3)
  see https://github.com/substack/module-deps/pull/99
- remove unused deps
- update browser-pack & fix charset bug (also uses streams3)
- use latest node in travis
- remove node 0.8 from travis
- Merge pull request [#1362](https://github.com/substack/node-browserify/issues/1362) from mnichols/master
  bump buffer to 3.4.3 to fix maximum call stack exceeded errors
- Merge pull request [#1393](https://github.com/substack/node-browserify/issues/1393) from emilbayes/patch-1
  Links to the wrong querystring module
- Merge pull request [#1396](https://github.com/substack/node-browserify/issues/1396) from stevemao/patch-3
  travis: test on node4 not "4.0.0"
- travis: test on node4 not "4.0.0"
- Links to the wrong querystring module
  Previously linked to `querystring` while it actually depends on `querystring-es3`
