### PR TITLE
Update "browserify" to version ^12.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "resource-loader": "^1.6.2"
   },
   "devDependencies": {
-    "browserify": "^11.1.0",
+    "browserify": "^12.0.1",
     "chai": "^3.2.0",
     "del": "^2.0.2",
     "gulp": "^3.9.0",


### PR DESCRIPTION
#12.0.1 / 2015-10-28
- transform tests
#12.0.0 / 2015-10-26
- 12.0.0
- update devdeps
- update glob and shell-quote
- update builtins deps
  These mostly include updates for newer versions of node. stream-http dropped IE8 support - needs shims to work (see [#1384](https://github.com/substack/node-browserify/issues/1384)).
- update deps for streams3
- update module-deps & fix symlink bug (also uses streams3)
  see https://github.com/substack/module-deps/pull/99
