### PR TITLE
Update "gulp-jshint" to version ^2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "gulp-cached": "^1.1.0",
     "gulp-concat": "^2.6.0",
     "gulp-debug": "^2.1.0",
-    "gulp-jshint": "^1.11.2",
+    "gulp-jshint": "^2.0.0",
     "gulp-mirror": "^0.4.0",
     "gulp-plumber": "^1.0.1",
     "gulp-rename": "^1.2.2",


### PR DESCRIPTION
#2.0.0 / 2015-11-19
- version 2.0.0
- added note about jshint peerDependency
- Merge pull request [#120](https://github.com/spalger/gulp-jshint/issues/120) from spalger/jshintAsPeer
  [npm] move jshint to peerDependencies
